### PR TITLE
Disable debug assertions on release builds

### DIFF
--- a/rtil/Cargo.toml
+++ b/rtil/Cargo.toml
@@ -12,7 +12,6 @@ byteorder = "1.4.3"
 backtrace = "0.3.64"
 crossbeam-channel = "0.5.2"
 memoffset = "0.9.1"
-#rebo = { path = "../../rebo/rebo" }
 rebo = { git = "https://github.com/oberien/rebo", rev = "6d10fe95fa9215442afcfee465ea01f786553b67" }
 itertools = "0.14.0"
 clipboard = "0.5.0"
@@ -35,10 +34,6 @@ atomic_float = "1.1.0"
 chrono = {  version = "0.4.39", features = ["serde"] }
 livesplit-core = "0.13.0"
 hook = { path = "../hook" }
-#iced = { path = "../../iced", features = ["advanced"] }
-#iced_runtime = { path = "../../iced/runtime" }
-#iced_wgpu = { path = "../../iced/wgpu" }
-#iced_tiny_skia = { path = "../../iced/tiny_skia" }
 iced = { git = "https://github.com/oberien/iced", rev = "0a4caa2b9dba31f7f239b2ee5fdb53ab32b1420d", features = ["advanced"] }
 iced_runtime = { git = "https://github.com/oberien/iced", rev = "0a4caa2b9dba31f7f239b2ee5fdb53ab32b1420d" }
 iced_wgpu = { git = "https://github.com/oberien/iced", rev = "0a4caa2b9dba31f7f239b2ee5fdb53ab32b1420d" }
@@ -60,11 +55,13 @@ name = "rtil"
 crate-type = ["dylib"]
 
 [profile.dev]
+debug = "full"
+debug-assertions = true
 panic = 'abort'
 
 [profile.release]
-debug = "full"
-debug-assertions = true
+debug = false
+debug-assertions = false
 panic = 'abort'
 
 [patch.crates-io]


### PR DESCRIPTION
This change also enables debug assertions on dev builds. This is a band-aid for a crash that is specifically caused by a runtime debug assertion in the wgpu library Vulkan backend. This assertion was instantly crashing Refunct when the TAS loaded.

Disabling the assertion _appears_ to not affect gameplay at all, so while this option is sort of nuclear, it works on my machine. 

¯\\_(ツ)_/¯