### PR TITLE
Add a debug helper script

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -13,6 +13,7 @@ cd ..
 echo Copying files
 copy rtil\target\i686-pc-windows-msvc\release\rtil.dll build\practice-windows
 copy tool\target\i686-pc-windows-msvc\debug\refunct-tas.exe build\practice-windows
+copy tool\debug.bat build\practice-windows
 copy tool\main.re build\practice-windows
 copy tool\prelude.re build\practice-windows
 copy tool\component.re build\practice-windows

--- a/tool/debug.bat
+++ b/tool/debug.bat
@@ -1,0 +1,2 @@
+.\refunct-tas.exe
+pause


### PR DESCRIPTION
This adds a script that simply runs `refunct-tas.exe`, then keeps the cmd window from closing after it quits, so that users can more easily get any errors they might encounter by double clicking the script instead of the exe.