### PR TITLE
Reset velocity when respawned by hitting the kill plane

### DIFF
--- a/rtil/Cargo.lock
+++ b/rtil/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "bimap",
  "bitflags 2.10.0",
  "futures-util",
+ "log 0.4.28",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4710,7 +4711,6 @@ dependencies = [
  "once_cell",
  "opener",
  "protocol",
- "rand 0.9.2",
  "rebo",
  "sanitize-filename",
  "serde",
@@ -5114,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5133,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rtil/Cargo.toml
+++ b/rtil/Cargo.toml
@@ -26,7 +26,6 @@ bit_field = "0.10.2"
 image = "0.25.6"
 ureq = "3.0.11"
 corosensei = "0.2.2"
-rand = "0.9.2"
 
 tokio = { version = "1.40.0", features = ["full"] }
 archipelago_rs = { git = "https://github.com/nex3/archipelago_rs", rev = "12a9385fb9f0df8d863a64750e44352bc1cbbeca" }

--- a/rtil/src/native/uworld.rs
+++ b/rtil/src/native/uworld.rs
@@ -196,7 +196,7 @@ impl UWorld {
             key.get_field("Value").unwrap::<&Cell<f32>>().set(red);
         }
     }
-    pub fn set_stars_brightness(time: TimeOfDay, brightness: f32) {
+    pub fn set_stars_brightness(brightness: f32) {
         let obj = unsafe { ObjectWrapper::new(UMyGameInstance::get_umygameinstance() as *mut UObject) };
         let keys = obj.get_field("WorldReferences")
             .field("TimeOfDay")
@@ -204,10 +204,9 @@ impl UWorld {
             .field("FloatCurve")
             .field("Keys")
             .unwrap::<ArrayWrapper<StructValueWrapper>>();
-        match time {
-            TimeOfDay::Day => keys.get(0).unwrap().get_field("Value").unwrap::<&Cell<f32>>().set(brightness),
-            TimeOfDay::Night => keys.get(1).unwrap().get_field("Value").unwrap::<&Cell<f32>>().set(brightness),
-        }
+        keys.get(0).unwrap().get_field("Value").unwrap::<&Cell<f32>>().set(brightness);
+        keys.get(1).unwrap().get_field("Value").unwrap::<&Cell<f32>>().set(brightness);
+        
     }
 
     pub fn set_sky_light_intensity(intensity: f32) {

--- a/rtil/src/threads/archipelago.rs
+++ b/rtil/src/threads/archipelago.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+
 use std::error::Error;
 use std::thread;
 use archipelago_rs::client::{ArchipelagoClient, ArchipelagoClientReceiver, ArchipelagoClientSender};
@@ -6,7 +6,6 @@ use archipelago_rs::protocol::{ClientStatus, ServerMessage, Bounce, BounceData, 
 use crossbeam_channel::Sender;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::task::AbortHandle;
-use rand::seq::IndexedRandom;
 use crate::threads::{ArchipelagoToRebo, ReboToArchipelago};
 
 pub fn run(archipelago_rebo_tx: Sender<ArchipelagoToRebo>, mut rebo_archipelago_rx: UnboundedReceiver<ReboToArchipelago>) {
@@ -35,14 +34,6 @@ pub fn run(archipelago_rebo_tx: Sender<ArchipelagoToRebo>, mut rebo_archipelago_
                             receiver_abort_handle = Some(join_handle.abort_handle());
 
                         },
-                        ReboToArchipelago::ConnectUpdate { items_handling, tags } => {
-                            if let Some(sender) = sender.as_mut() {
-                                sender.send(ClientMessage::ConnectUpdate(ConnectUpdate {
-                                    items_handling: items_handling.bits(),
-                                    tags
-                                })).await?;
-                            }
-                        }
                         ReboToArchipelago::ClientMessage(msg) => {
                             if let Some(sender) = sender.as_mut() {
                                 sender.send(msg).await?;

--- a/rtil/src/threads/mod.rs
+++ b/rtil/src/threads/mod.rs
@@ -1,5 +1,5 @@
 use crate::native::Hooks;
-use archipelago_rs::protocol::{ClientMessage, ServerMessage, ItemsHandlingFlags};
+use archipelago_rs::protocol::{ClientMessage, ServerMessage};
 
 mod listener;
 mod stream_read;
@@ -43,24 +43,19 @@ pub enum ReboToStream {
 
 #[derive(Debug)]
 pub enum ArchipelagoToRebo {
-    ServerMessage(ServerMessage<serde_json::Value>),
+    ServerMessage(ServerMessage),
     ConnectionAborted,
 }
-//#[derive(Debug)]
+#[derive(Debug)]
 pub enum ReboToArchipelago {
     Connect {
         server_and_port: String,
         game: String,
         slot: String,
         password: Option<String>,
-        items_handling: ItemsHandlingFlags,
+        items_handling: Option<i32>,
         tags: Vec<String>,
     },
-    ConnectUpdate {
-        items_handling: ItemsHandlingFlags,
-        tags: Vec<String>,
-    },
-    SendDeath,
     ClientMessage(ClientMessage),
     Disconnect,
     LocationChecks { locations: Vec<i64> },

--- a/tool/archipelago_log.re
+++ b/tool/archipelago_log.re
@@ -76,27 +76,6 @@ fn ap_log_info(text: string)    { ap_log(List::of(ColorfulText { text: text, col
 fn ap_log_warning(text: string) { ap_log(List::of(ColorfulText { text: text, color: AP_COLOR_YELLOW })); }
 fn ap_log_error(text: string)   { ap_log(List::of(ColorfulText { text: text, color: AP_COLOR_RED })); }
 
-fn archipelago_received_death(source: string, cause: string) {
-    let mut message = List::new();
-    match cause {
-        "" => {
-            message.push(ColorfulText { text: source, color: COLOR_RED });
-            message.push(ColorfulText { text: " died", color: AP_COLOR_YELLOW });
-        },
-        _ => {
-            for part in cause.split(source) {
-                if part != "" {
-                    message.push(ColorfulText { text: part, color: AP_COLOR_YELLOW });
-                }
-                message.push(ColorfulText { text: source, color: COLOR_RED });
-            }
-            message.pop();
-        }
-    }
-
-    ap_log(message);
-}
-
 fn archipelago_print_json_message(json_message: ReboPrintJSONMessage) {
     let mut message = List::new();
 

--- a/tool/archipelago_ui.re
+++ b/tool/archipelago_ui.re
@@ -117,18 +117,6 @@ fn create_archipelago_connection_details_menu() -> Ui {
     }));
 
     if ARCHIPELAGO_STATE.ap_connected {
-        elements.push(UiElement::Chooser(Chooser {
-            label: Text { text: "Death Link" },
-            options: List::of(Text { text: "On" }, Text { text: "Off" }),
-            selected: if Tas::is_death_link_on() { 0 } else { 1 },
-            onchange: fn(index: int) {
-                if index == 0 {
-                    Tas::set_death_link(true);
-                } else {
-                    Tas::set_death_link(false);
-                }
-            },
-        }));
         elements.push(UiElement::Button(UiButton {
             label: Text { text: "Disconnect" },
             onclick: fn(label: Text) {
@@ -174,12 +162,12 @@ fn create_archipelago_connection_details_menu() -> Ui {
 fn create_archipelago_settings_menu() -> Ui {
     Ui::new("Settings", List::of(
         UiElement::FloatInput(FloatInput {
-            label: Text { text: "UI Scale (0.0 - 1.0)" },
+            label: Text { text: "UI Scale (0.2 - 1.0)" },
             input: f"{SETTINGS.ui_scale}",
             onclick: fn(input: string) {},
             onchange: fn(input: string) {
                 match input.parse_float() {
-                    Result::Ok(size) => if 0.0 <= size && size <= 1.0 {
+                    Result::Ok(size) => if 0.2 <= size && size <= 1.0 {
                         SETTINGS.ui_scale = size;
                         SETTINGS.store();
                     },

--- a/tool/main.re
+++ b/tool/main.re
@@ -57,6 +57,6 @@ loop {
         }
     }
     Tas::show_hud();
-    Tas::set_sky_time_speed(SETTINGS.sky_time_speed);
+    Tas::set_sky_time_speed(SETTINGS.sky_time_speed, SETTINGS.sky_time_speed);
     step_frame(tick_mode);
 }

--- a/tool/settings.re
+++ b/tool/settings.re
@@ -194,7 +194,7 @@ impl Settings {
             }
         };
         Settings {
-            ui_scale: get_float("ui_scale", 1.),
+            ui_scale: get_float("ui_scale", 0.5),
             show_character_stats: get_bool("show_character_stats", false),
             show_game_stats: get_bool("show_game_stats", false),
             minimap_enabled: get_bool("minimap_enabled", false),

--- a/tool/world_options.re
+++ b/tool/world_options.re
@@ -1,23 +1,23 @@
 Tas::set_reflection_render_scale(SETTINGS.reflection_render_scale);
-Tas::set_lighting_casts_shadows(SETTINGS.lighting_casts_shadows);
-Tas::set_sky_light_enabled(SETTINGS.sky_light_enabled);
-Tas::set_time_dilation(SETTINGS.time_dilation);
+Tas::set_lighting_casts_shadows(SETTINGS.lighting_casts_shadows, SETTINGS.lighting_casts_shadows);
+Tas::set_sky_light_enabled(SETTINGS.sky_light_enabled, SETTINGS.sky_light_enabled);
+Tas::set_time_dilation(SETTINGS.time_dilation, SETTINGS.time_dilation);
 Tas::set_gravity(SETTINGS.gravity);
 Tas::set_time_of_day(SETTINGS.time_of_day);
-Tas::set_sky_time_speed(SETTINGS.sky_time_speed);
+Tas::set_sky_time_speed(SETTINGS.sky_time_speed, SETTINGS.sky_time_speed);
 Tas::set_sky_light_brightness(SETTINGS.sky_light_brightness);
 Tas::set_sky_light_intensity(SETTINGS.sky_light_intensity);
-Tas::set_stars_brightness(TimeOfDay::Day, SETTINGS.day_stars_brightness);
-Tas::set_stars_brightness(TimeOfDay::Night, SETTINGS.night_stars_brightness);
-Tas::set_fog_enabled(SETTINGS.fog_enabled);
-Tas::set_cloud_speed(SETTINGS.cloud_speed);
+Tas::set_stars_brightness(SETTINGS.day_stars_brightness, SETTINGS.day_stars_brightness);
+Tas::set_fog_enabled(SETTINGS.fog_enabled, SETTINGS.fog_enabled);
+Tas::set_cloud_speed(SETTINGS.cloud_speed, SETTINGS.cloud_speed);
 Tas::set_gamma(SETTINGS.display_gamma);
 Tas::set_kill_z(SETTINGS.kill_z);
-Tas::set_cloud_redness(SETTINGS.cloud_redness);
+Tas::set_cloud_redness(SETTINGS.cloud_redness, SETTINGS.cloud_redness);
 Tas::set_outro_dilated_duration(SETTINGS.outro_dilated_duration);
 Tas::set_outro_time_dilation(SETTINGS.outro_time_dilation);
-Tas::set_sun_redness(SETTINGS.sun_redness);
-Tas::set_screen_percentage(SETTINGS.screen_percentage);
+Tas::set_sun_redness(SETTINGS.sun_redness, SETTINGS.sun_redness);
+Tas::set_screen_percentage(SETTINGS.screen_percentage, SETTINGS.screen_percentage);
+
 
 fn create_world_options_menu() -> Ui {
     let mut lighting_casts_shadows_button_text = Text { text: f"Lighting Casts Shadows: {SETTINGS.lighting_casts_shadows}" };
@@ -28,7 +28,7 @@ fn create_world_options_menu() -> Ui {
             label: lighting_casts_shadows_button_text,
             onclick: fn(label: Text) {
                 SETTINGS.toggle_lighting_casts_shadows();
-                Tas::set_lighting_casts_shadows(SETTINGS.lighting_casts_shadows);
+                Tas::set_lighting_casts_shadows(SETTINGS.lighting_casts_shadows, SETTINGS.lighting_casts_shadows);
                 lighting_casts_shadows_button_text.text = f"Lighting Casts Shadows: {SETTINGS.lighting_casts_shadows}";
             },
         }),
@@ -36,7 +36,7 @@ fn create_world_options_menu() -> Ui {
             label: sky_light_enabled_button_text,
             onclick: fn(label: Text) {
                 SETTINGS.toggle_sky_light_enabled();
-                Tas::set_sky_light_enabled(SETTINGS.sky_light_enabled);
+                Tas::set_sky_light_enabled(SETTINGS.sky_light_enabled, SETTINGS.sky_light_enabled);
                 sky_light_enabled_button_text.text = f"Sky Light Enabled: {SETTINGS.sky_light_enabled}";
             },
         }),
@@ -44,7 +44,7 @@ fn create_world_options_menu() -> Ui {
             label: fog_enabled_button_text,
             onclick: fn(label: Text) {
                 SETTINGS.toggle_fog_enabled();
-                Tas::set_fog_enabled(SETTINGS.fog_enabled);
+                Tas::set_fog_enabled(SETTINGS.fog_enabled, SETTINGS.fog_enabled);
                 fog_enabled_button_text.text = f"Fog Enabled: {SETTINGS.fog_enabled}";
             },
         }),
@@ -56,7 +56,7 @@ fn create_world_options_menu() -> Ui {
                     Result::Ok(dilation) => {
                         SETTINGS.time_dilation = dilation;
                         SETTINGS.store();
-                        Tas::set_time_dilation(dilation);
+                        Tas::set_time_dilation(dilation, dilation);
                     },
                     Result::Err(e) => {},
                 }
@@ -145,7 +145,7 @@ fn create_world_options_menu() -> Ui {
             onchange: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(speed) => {
-                        Tas::set_sky_time_speed(speed);
+                        Tas::set_sky_time_speed(speed, speed);
                         SETTINGS.sky_time_speed = speed;
                         SETTINGS.store();
                     },
@@ -184,29 +184,14 @@ fn create_world_options_menu() -> Ui {
             },
         }),
         UiElement::FloatInput(FloatInput {
-            label: Text { text: "Day Stars Brightness" },
+            label: Text { text: "Stars Brightness" },
             input: f"{SETTINGS.day_stars_brightness}",
             onclick: fn(input: string) {},
             onchange: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(brightness) => {
-                        Tas::set_stars_brightness(TimeOfDay::Day, brightness);
+                        Tas::set_stars_brightness(brightness, brightness);
                         SETTINGS.day_stars_brightness = brightness;
-                        SETTINGS.store();
-                    },
-                    Result::Err(e) => {},
-                }
-            },
-        }),
-        UiElement::FloatInput(FloatInput {
-            label: Text { text: "Night Stars Brightness" },
-            input: f"{SETTINGS.night_stars_brightness}",
-            onclick: fn(input: string) {},
-            onchange: fn(input: string) {
-                match input.parse_float() {
-                    Result::Ok(brightness) => {
-                        Tas::set_stars_brightness(TimeOfDay::Night, brightness);
-                        SETTINGS.night_stars_brightness = brightness;
                         SETTINGS.store();
                     },
                     Result::Err(e) => {},
@@ -220,7 +205,7 @@ fn create_world_options_menu() -> Ui {
             onchange: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(color) => {
-                        Tas::set_sun_redness(color);
+                        Tas::set_sun_redness(color, color);
                         SETTINGS.sun_redness = color;
                         SETTINGS.store();
                     },
@@ -235,7 +220,7 @@ fn create_world_options_menu() -> Ui {
             onchange: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(color) => {
-                        Tas::set_cloud_redness(color);
+                        Tas::set_cloud_redness(color, color);
                         SETTINGS.cloud_redness = color;
                         SETTINGS.store();
                     },
@@ -249,7 +234,7 @@ fn create_world_options_menu() -> Ui {
             onclick: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(speed) => {
-                        Tas::set_cloud_speed(speed);
+                        Tas::set_cloud_speed(speed, speed);
                         SETTINGS.cloud_speed = speed;
                         SETTINGS.store();
                     },
@@ -295,7 +280,7 @@ fn create_world_options_menu() -> Ui {
             onchange: fn(input: string) {
                 match input.parse_float() {
                     Result::Ok(percentage) => {
-                        Tas::set_screen_percentage(percentage);
+                        Tas::set_screen_percentage(percentage, percentage);
                         SETTINGS.screen_percentage = percentage;
                         SETTINGS.store();
                     },


### PR DESCRIPTION
So far, hitting the kill plane leads to being respawned without the velocity being reset, because of this you can end up having the velocity send you straight back into the water leading to another respawn. It also seems that respawning does reset _something_ causing you to no longer slow down in the air when pressing nothing, causing you to be sent flying into the water until you proactively accelerate in the other direction.

This change hooks into the `FellOutOfWorld` function called by Unreal Engine when the actor hits the kill plane and resets the actors velocity on respawn to prevent that. It also resets the camera rotation to make it less disorienting to be respawned.

This also acts as a first step towards implementing #13.

I have not tested that the windows specific changes actually work correctly as I don't currently have a windows machine available, so I'd like to ask for @nielrenned or @spinerak to check that before this gets merged and let me know if it's causing issues.