### PR TITLE
color code and sort the minigame list

### DIFF
--- a/tool/archipelago_ui.re
+++ b/tool/archipelago_ui.re
@@ -697,317 +697,358 @@ fn create_list_of_minigames_with_checks(txt: string) -> List<ColorfulText> {
 }
 
 fn create_archipelago_gamemodes_menu() -> Ui {
-    Ui::new("Select Game Mode:", List::of(
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.just_clique {
-                    "Move rando (locked)"
-                } else {
-                    "Move rando (main)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if ARCHIPELAGO_STATE.just_clique {
-                    // log("Move rando gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to main game");
-                archipelago_init(0);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_vanilla_minigame {
-                    "Vanilla game"
-                } else {
-                    "Vanilla game (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_vanilla_minigame {
-                    // log("Vanilla game gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to OG game");
-                archipelago_init(1);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_button_galore_minigame {
-                    "Button Galore"
-                } else {
-                    "Button Galore (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_button_galore_minigame {
-                    // log("Button Galore gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Button Galore");
-                archipelago_init(2);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_seeker_minigame {
-                    "Seeker"
-                } else {
-                    "Seeker (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_seeker_minigame {
-                    // log("Seeker gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Seeker");
-                archipelago_init(3);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_OG_randomizer {
-                    "OG Randomizer"
-                } else {
-                    "OG Randomizer (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_OG_randomizer {
-                    // log("OG Randomizer gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to OG Randomizer");
-                archipelago_init(4);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_block_brawl {
-                    "Block Brawl"
-                } else {
-                    "Block Brawl (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_block_brawl {
-                    // log("Block Brawl gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Block Brawl");
-                ARCHIPELAGO_STATE.block_brawl_alt = false;
-                archipelago_init(5); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_block_brawl {
-                    "Block Brawl ALT"
-                } else {
-                    "Block Brawl ALT (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_block_brawl {
-                    // log("Block Brawl gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Block Brawl ALT");
-                ARCHIPELAGO_STATE.block_brawl_alt = true;
-                archipelago_init(5); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_climb_line {
-                    "Climb Line"
-                } else {
-                    "Climb Line (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_climb_line {
-                    // log("Climb Line gamemode is locked!");
-                    return;
-                }
-                archipelago_init(6); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_climb_spiral {
-                    "Climb Spiral"
-                } else {
-                    "Climb Spiral (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_climb_spiral {
-                    // log("Climb Spiral gamemode is locked!");
-                    return;
-                }
-                archipelago_init(7); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_climb_chaos {
-                    "Climb Chaos"
-                } else {
-                    "Climb Chaos (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_climb_chaos {
-                    // log("Climb Chaos gamemode is locked!");
-                    return;
-                }
-                archipelago_init(8); 
-                leave_ui(); 
-            },
-        }),
-        // UiElement::Button(UiButton {
-        //     label: Text { text: "[test] Hillside Cave Secret" },
-        //     onclick: fn(label: Text) { 
-        //         archipelago_init(9); 
-        //         leave_ui(); 
-        //     },
-        // }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_block_blub {
-                    "Block Blub"
-                } else {
-                    "Block Blub (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_block_blub {
-                    // log("Block Blub gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Block Blub");
-                archipelago_init(11); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_refunct_mountain_minigame {
-                    "Refunct Mountain"
-                } else {
-                    "Refunct Mountain (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_refunct_mountain_minigame {
-                    // log("Refunct Mountain gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Refunct Mountain");
-                archipelago_init(12);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_rando_mountain_minigame {
-                    "Rando Mountain"
-                } else {
-                    "Rando Mountain (locked)"
-                }
-            } },
-            onclick: fn(label: Text) {
-                if !ARCHIPELAGO_STATE.unlock_rando_mountain_minigame {
-                    // log("Rando Mountain gamemode is locked!");
-                    return;
-                }
-                // log("Set gamemode to Rando Mountain");
-                archipelago_init(13);
-                leave_ui();
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_climb_narrow {
-                    "Climb Narrow"
-                } else {
-                    "Climb Narrow (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_climb_narrow {
-                    // log("Climb Narrow gamemode is locked!");
-                    return;
-                }
-                archipelago_init(14); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.unlock_funny_bridge_game_minigame {
-                    "Funny Bridge Game"
-                } else {
-                    "Funny Bridge Game (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.unlock_funny_bridge_game_minigame {
-                    // log("Funny Bridge Game gamemode is locked!");
-                    return;
-                }
-                archipelago_init(16); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
-            label: Text { text: {
-                if ARCHIPELAGO_STATE.has_clique {
-                    "Clique"
-                } else {
-                    "Clique (locked)"
-                }
-            } },
-            onclick: fn(label: Text) { 
-                if !ARCHIPELAGO_STATE.has_clique {
-                    // log("Clique gamemode is locked!");
-                    return;
-                }
-                archipelago_init(17); 
-                leave_ui(); 
-            },
-        }),
-        UiElement::Button(UiButton {
+    let unlocked = List::new();
+    let locked = List::new();
+
+    let make_gamemode_button: fn(UiButton, bool) = fn(button: UiButton, is_unlocked: bool) {
+        let el = UiElement::ColorButton(UiColorButton {
+            label: button.label,
+            onclick: button.onclick,
+            color_default: if is_unlocked { COLOR_WHITE } else { COLOR_DARK_GRAY },
+            color_selected: if is_unlocked { COLOR_GREEN } else { AP_COLOR_RED },
+        });
+        if is_unlocked { unlocked.push(el) } else { locked.push(el) }
+    };
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.just_clique {
+                "Move rando (locked)"
+            } else {
+                "Move rando (main)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if ARCHIPELAGO_STATE.just_clique {
+                // log("Move rando gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to main game");
+            archipelago_init(0);
+            leave_ui();
+        },
+    }, !ARCHIPELAGO_STATE.just_clique);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_vanilla_minigame {
+                "Vanilla game"
+            } else {
+                "Vanilla game (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_vanilla_minigame {
+                // log("Vanilla game gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to OG game");
+            archipelago_init(1);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_vanilla_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_button_galore_minigame {
+                "Button Galore"
+            } else {
+                "Button Galore (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_button_galore_minigame {
+                // log("Button Galore gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Button Galore");
+            archipelago_init(2);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_button_galore_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_seeker_minigame {
+                "Seeker"
+            } else {
+                "Seeker (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_seeker_minigame {
+                // log("Seeker gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Seeker");
+            archipelago_init(3);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_seeker_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_OG_randomizer {
+                "OG Randomizer"
+            } else {
+                "OG Randomizer (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_OG_randomizer {
+                // log("OG Randomizer gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to OG Randomizer");
+            archipelago_init(4);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_OG_randomizer);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_block_brawl {
+                "Block Brawl"
+            } else {
+                "Block Brawl (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_block_brawl {
+                // log("Block Brawl gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Block Brawl");
+            ARCHIPELAGO_STATE.block_brawl_alt = false;
+            archipelago_init(5);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_block_brawl);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_block_brawl {
+                "Block Brawl ALT"
+            } else {
+                "Block Brawl ALT (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_block_brawl {
+                // log("Block Brawl gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Block Brawl ALT");
+            ARCHIPELAGO_STATE.block_brawl_alt = true;
+            archipelago_init(5);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_block_brawl);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_climb_line {
+                "Climb Line"
+            } else {
+                "Climb Line (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_climb_line {
+                // log("Climb Line gamemode is locked!");
+                return;
+            }
+            archipelago_init(6);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_climb_line);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_climb_spiral {
+                "Climb Spiral"
+            } else {
+                "Climb Spiral (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_climb_spiral {
+                // log("Climb Spiral gamemode is locked!");
+                return;
+            }
+            archipelago_init(7);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_climb_spiral);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_climb_chaos {
+                "Climb Chaos"
+            } else {
+                "Climb Chaos (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_climb_chaos {
+                // log("Climb Chaos gamemode is locked!");
+                return;
+            }
+            archipelago_init(8);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_climb_chaos);
+
+    // UiElement::Button(UiButton {
+    //     label: Text { text: "[test] Hillside Cave Secret" },
+    //     onclick: fn(label: Text) {
+    //         archipelago_init(9);
+    //         leave_ui();
+    //     },
+    // }),
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_block_blub {
+                "Block Blub"
+            } else {
+                "Block Blub (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_block_blub {
+                // log("Block Blub gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Block Blub");
+            archipelago_init(11);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_block_blub);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_refunct_mountain_minigame {
+                "Refunct Mountain"
+            } else {
+                "Refunct Mountain (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_refunct_mountain_minigame {
+                // log("Refunct Mountain gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Refunct Mountain");
+            archipelago_init(12);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_refunct_mountain_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_rando_mountain_minigame {
+                "Rando Mountain"
+            } else {
+                "Rando Mountain (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_rando_mountain_minigame {
+                // log("Rando Mountain gamemode is locked!");
+                return;
+            }
+            // log("Set gamemode to Rando Mountain");
+            archipelago_init(13);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_rando_mountain_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_climb_narrow {
+                "Climb Narrow"
+            } else {
+                "Climb Narrow (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_climb_narrow {
+                // log("Climb Narrow gamemode is locked!");
+                return;
+            }
+            archipelago_init(14);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_climb_narrow);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.unlock_funny_bridge_game_minigame {
+                "Funny Bridge Game"
+            } else {
+                "Funny Bridge Game (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.unlock_funny_bridge_game_minigame {
+                // log("Funny Bridge Game gamemode is locked!");
+                return;
+            }
+            archipelago_init(16);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.unlock_funny_bridge_game_minigame);
+
+    make_gamemode_button(UiButton {
+        label: Text { text: {
+            if ARCHIPELAGO_STATE.has_clique {
+                "Clique"
+            } else {
+                "Clique (locked)"
+            }
+        } },
+        onclick: fn(label: Text) {
+            if !ARCHIPELAGO_STATE.has_clique {
+                // log("Clique gamemode is locked!");
+                return;
+            }
+            archipelago_init(17);
+            leave_ui();
+        },
+    }, ARCHIPELAGO_STATE.has_clique);
+
+    let elems = List::new();
+    elems.extend(unlocked);
+    elems.extend(locked);
+    elems.extend(List::of(
+        UiElement::ColorButton(UiColorButton {
             label: Text { text: "[TEST] Frogger" },
-            onclick: fn(label: Text) { 
-                archipelago_init(10); 
-                leave_ui(); 
+            onclick: fn(label: Text) {
+                archipelago_init(10);
+                leave_ui();
             },
+            color_default: AP_COLOR_CYAN,
+            color_selected: COLOR_GREEN,
         }),
-        UiElement::Button(UiButton {
+        UiElement::ColorButton(UiColorButton {
             label: Text { text: "[TEST] Block Beat" },
-            onclick: fn(label: Text) { 
-                archipelago_init(15); 
-                leave_ui(); 
+            onclick: fn(label: Text) {
+                archipelago_init(15);
+                leave_ui();
             },
+            color_default: AP_COLOR_CYAN,
+            color_selected: COLOR_GREEN,
         }),
-        UiElement::Button(UiButton {
+        UiElement::ColorButton(UiColorButton {
             label: Text { text: "Back" },
             onclick: fn(label: Text) { leave_ui(); },
+            color_default: COLOR_WHITE,
+            color_selected: AP_COLOR_RED,
         }),
-    ))
+    ));
+
+    Ui::new("Select Game Mode:", elems)
 }
 
 fn get_status_text_lines() -> List<ColorfulText> {  

--- a/tool/ui.re
+++ b/tool/ui.re
@@ -44,6 +44,7 @@ impl Ui {
 
 enum UiElement {
     Button(UiButton),
+    ColorButton(UiColorButton),
     Input(Input),
     FloatInput(FloatInput),
     Slider(Slider),
@@ -51,6 +52,12 @@ enum UiElement {
 }
 struct UiButton {
     label: Text,
+    onclick: fn(Text),
+}
+struct UiColorButton {
+    label: Text,
+    color_default: Color,
+    color_selected: Color,
     onclick: fn(Text),
 }
 struct Input {
@@ -359,8 +366,9 @@ impl Ui {
 
         let mut i = 0;
         for element in self.elements {
-            let color = if self.selected == i { COLOR_GREEN } else { COLOR_WHITE };
-            element.draw(10. + padding + i.to_float() * padding, color);
+            let is_selected = self.selected == i;
+            let color = if is_selected { COLOR_GREEN } else { COLOR_WHITE };
+            element.draw(10. + padding + i.to_float() * padding, color, is_selected);
             i = i + 1;
         }
     }
@@ -370,6 +378,7 @@ impl UiElement {
     fn onclick(self) {
         match self {
             UiElement::Button(button) => button.onclick(),
+            UiElement::ColorButton(button) => button.onclick(),
             UiElement::Input(input) => input.onclick(),
             UiElement::FloatInput(input) => input.onclick(),
             UiElement::Slider(slider) => (),
@@ -379,6 +388,7 @@ impl UiElement {
     fn onkey(self, key: KeyCode) {
         match self {
             UiElement::Button(button) => (),
+            UiElement::ColorButton(button) => (),
             UiElement::Input(input) => input.onkey(key),
             UiElement::FloatInput(input) => input.onkey(key),
             UiElement::Slider(slider) => slider.onkey(key),
@@ -388,15 +398,17 @@ impl UiElement {
     fn onchar(self, c: string) {
         match self {
             UiElement::Button(button) => (),
+            UiElement::ColorButton(button) => (),
             UiElement::Input(input) => input.onchar(c),
             UiElement::FloatInput(input) => input.onchar(c),
             UiElement::Slider(slider) => (),
             UiElement::Chooser(chooser) => (),
         }
     }
-    fn draw(self, y: float, color: Color) {
+    fn draw(self, y: float, color: Color, is_selected: bool) {
         match self {
             UiElement::Button(button) => button.draw(y, color),
+            UiElement::ColorButton(button) => button.draw(y, if is_selected { button.color_selected } else { button.color_default }),
             UiElement::Input(input) => input.draw(y, color),
             UiElement::FloatInput(input) => input.draw(y, color),
             UiElement::Slider(slider) => slider.draw(y, color),
@@ -406,6 +418,7 @@ impl UiElement {
     fn text(self) -> string {
         match self {
             UiElement::Button(button) => button.text(),
+            UiElement::ColorButton(button) => button.text(),
             UiElement::Input(input) => input.text(),
             UiElement::FloatInput(input) => input.text(),
             UiElement::Slider(slider) => slider.text(),
@@ -415,6 +428,25 @@ impl UiElement {
 }
 
 impl UiButton {
+    fn onclick(self) {
+        let f = self.onclick;
+        f(self.label);
+    }
+    fn draw(self, y: float, color: Color) {
+        Tas::draw_text(DrawText {
+            text: self.text(),
+            color: color,
+            x: 0.,
+            y: y,
+            scale: SETTINGS.ui_scale,
+            scale_position: true,
+        })
+    }
+    fn text(self) -> string {
+        f"    {self.label.text}"
+    }
+}
+impl UiColorButton {
     fn onclick(self) {
         let f = self.onclick;
         f(self.label);


### PR DESCRIPTION
This change causes minigame entries in the list to render in grey text if not yet unlocked, and white if unlocked (red and green respectively if selected). Test entries are shown in cyan.  
Additionally unlocked minigames are listed at the top, followed by locked ones, then tests.  
<img width="961" height="1176" alt="image" src="https://github.com/user-attachments/assets/71cd0c57-23e1-48f4-a20c-83f112bac4cf" />
